### PR TITLE
Allow Cmake to find system installed dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cmake-build-*
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,17 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.14)
 project(SDL2X11Emulation C)
 
-set(CMAKE_C_FLAGS_DEBUG -DDEBUG_SDL2X11_EMULATION)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+find_package(SDL2 REQUIRED)
+find_package(SDL2_ttf REQUIRED)
+find_package(SDL_gpu REQUIRED)
+find_package(Pixman REQUIRED)
+
+option(SDL2X11EMULATION_DEBUGGING "Enables debugging of the SDL2X11 emulation layer")
+if(SDL2X11EMULATION_DEBUGGING)
+    set(CMAKE_C_FLAGS_DEBUG -DDEBUG_SDL2X11_EMULATION)
+endif()
 
 add_library(sdl2X11Emulation SHARED
         include/X11/DECkeysym.h include/X11/HPkeysym.h include/X11/ImUtil.h
@@ -69,4 +79,11 @@ target_include_directories(sdl2X11Emulation
 
 target_link_libraries(
         sdl2X11Emulation
-        SDL2 SDL_gpu_shared SDL2_ttf pixman)
+        SDL2::SDL2 SDL2::TTF SDL_gpu Pixman
+)
+
+include(CheckIncludeFile)
+check_include_file("jni.h" HAVE_JNI)
+if(HAVE_JNI)
+    target_compile_options(sdl2X11Emulation PRIVATE -DHAVE_JNI)
+endif()

--- a/cmake/FindPixman.cmake
+++ b/cmake/FindPixman.cmake
@@ -1,0 +1,155 @@
+# - Try to find the PIXMAN library
+# Once done this will define
+#
+#  PIXMAN_ROOT_DIR - Set this variable to the root installation of PIXMAN
+#
+# Read-Only variables:
+#  PIXMAN_FOUND - system has the PIXMAN library
+#  PIXMAN_INCLUDE_DIR - the PIXMAN include directory
+#  PIXMAN_LIBRARIES - The libraries needed to use PIXMAN
+#  PIXMAN_VERSION - This is set to $major.$minor.$revision (eg. 0.9.8)
+
+#=============================================================================
+# Copyright 2012 Dmitry Baryshnikov <polimax at mail dot ru>
+# Copyright 2017 Simon Richter <Simon.Richter at hogyros dot de>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+find_package(PkgConfig)
+
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(_PIXMAN pixman-1)
+endif (PKG_CONFIG_FOUND)
+
+SET(_PIXMAN_ROOT_HINTS
+        $ENV{PIXMAN}
+        ${PIXMAN_ROOT_DIR}
+)
+SET(_PIXMAN_ROOT_PATHS
+        $ENV{PIXMAN}/src
+        /usr
+        /usr/local
+)
+SET(_PIXMAN_ROOT_HINTS_AND_PATHS
+        HINTS ${_PIXMAN_ROOT_HINTS}
+        PATHS ${_PIXMAN_ROOT_PATHS}
+)
+
+FIND_PATH(PIXMAN_INCLUDE_DIR
+        NAMES
+        pixman.h
+        HINTS
+        ${_PIXMAN_INCLUDEDIR}
+        ${_PIXMAN_ROOT_HINTS_AND_PATHS}
+        PATH_SUFFIXES
+        include
+        "include/pixman-1"
+)
+
+IF(NOT PKGCONFIG_FOUND AND WIN32 AND NOT CYGWIN)
+    # MINGW should go here too
+    IF(MSVC)
+        # Implementation details:
+        # We are using the libraries located in the VC subdir instead of the parent directory eventhough :
+        FIND_LIBRARY(PIXMAN
+                NAMES
+                pixman-1
+                ${_PIXMAN_ROOT_HINTS_AND_PATHS}
+                PATH_SUFFIXES
+                "lib"
+                "VC"
+                "lib/VC"
+        )
+
+        MARK_AS_ADVANCED(PIXMAN)
+        set( PIXMAN_LIBRARIES ${PIXMAN})
+    ELSEIF(MINGW)
+        # same player, for MingW
+        FIND_LIBRARY(PIXMAN
+                NAMES
+                pixman-1
+                ${_PIXMAN_ROOT_HINTS_AND_PATHS}
+                PATH_SUFFIXES
+                "lib"
+                "lib/MinGW"
+        )
+
+        MARK_AS_ADVANCED(PIXMAN)
+        set( PIXMAN_LIBRARIES ${PIXMAN})
+    ELSE(MSVC)
+        # Not sure what to pick for -say- intel, let's use the toplevel ones and hope someone report issues:
+        FIND_LIBRARY(PIXMAN
+                NAMES
+                pixman-1
+                HINTS
+                ${_PIXMAN_LIBDIR}
+                ${_PIXMAN_ROOT_HINTS_AND_PATHS}
+                PATH_SUFFIXES
+                lib
+        )
+
+        MARK_AS_ADVANCED(PIXMAN)
+        set( PIXMAN_LIBRARIES ${PIXMAN} )
+    ENDIF(MSVC)
+ELSE()
+
+    FIND_LIBRARY(PIXMAN_LIBRARY
+            NAMES
+            pixman-1
+            HINTS
+            ${_PIXMAN_LIBDIR}
+            ${_PIXMAN_ROOT_HINTS_AND_PATHS}
+            PATH_SUFFIXES
+            "lib"
+            "local/lib"
+    )
+
+    MARK_AS_ADVANCED(PIXMAN_LIBRARY)
+
+    # compat defines
+    SET(PIXMAN_LIBRARIES ${PIXMAN_LIBRARY})
+
+ENDIF()
+
+#message( STATUS "Pixman_FIND_VERSION=${Pixman_FIND_VERSION}.")
+#message( STATUS "PIXMAN_INCLUDE_DIR=${PIXMAN_INCLUDE_DIR}.")
+
+# Fetch version from pixman-version.h if a version was requested by find_package()
+if(PIXMAN_INCLUDE_DIR AND Pixman_FIND_VERSION)
+    file(READ "${PIXMAN_INCLUDE_DIR}/pixman-version.h" _PIXMAN_VERSION_H_CONTENTS)
+    string(REGEX REPLACE "^(.*\n)?#define[ \t]+PIXMAN_VERSION_MAJOR[ \t]+([0-9]+).*"
+            "\\2" PIXMAN_VERSION_MAJOR ${_PIXMAN_VERSION_H_CONTENTS})
+    string(REGEX REPLACE "^(.*\n)?#define[ \t]+PIXMAN_VERSION_MINOR[ \t]+([0-9]+).*"
+            "\\2" PIXMAN_VERSION_MINOR ${_PIXMAN_VERSION_H_CONTENTS})
+    string(REGEX REPLACE "^(.*\n)?#define[ \t]+PIXMAN_VERSION_MICRO[ \t]+([0-9]+).*"
+            "\\2" PIXMAN_VERSION_MICRO ${_PIXMAN_VERSION_H_CONTENTS})
+    set(PIXMAN_VERSION ${PIXMAN_VERSION_MAJOR}.${PIXMAN_VERSION_MINOR}.${PIXMAN_VERSION_MICRO}
+            CACHE INTERNAL "The version number for Pixman libraries")
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(Pixman
+        REQUIRED_VARS
+        PIXMAN_LIBRARIES
+        PIXMAN_INCLUDE_DIR
+        VERSION_VAR
+        PIXMAN_VERSION
+)
+
+MARK_AS_ADVANCED(PIXMAN_INCLUDE_DIR PIXMAN_LIBRARIES)
+
+if(PIXMAN_LIBRARIES AND NOT TARGET Pixman)
+    add_library(Pixman UNKNOWN IMPORTED)
+    set_target_properties(Pixman PROPERTIES
+            IMPORTED_LOCATION "${PIXMAN_LIBRARIES}"
+            INTERFACE_INCLUDE_DIRECTORIES "${PIXMAN_INCLUDE_DIR}")
+endif()

--- a/cmake/FindSDL2_ttf.cmake
+++ b/cmake/FindSDL2_ttf.cmake
@@ -1,0 +1,222 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#  Copyright 2019 Amine Ben Hassouna <amine.benhassouna@gmail.com>
+#  Copyright 2000-2019 Kitware, Inc. and Contributors
+#  All rights reserved.
+
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+
+#  * Neither the name of Kitware, Inc. nor the names of Contributors
+#    may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindSDL2_ttf
+------------
+
+Locate SDL2_ttf library
+
+This module defines the following 'IMPORTED' target:
+
+::
+
+  SDL2::TTF
+    The SDL2_ttf library, if found.
+    Have SDL2::SDL2 as a link dependency.
+
+
+
+This module will set the following variables in your project:
+
+::
+
+  SDL2_TTF_LIBRARIES, the name of the library to link against
+  SDL2_TTF_INCLUDE_DIRS, where to find the headers
+  SDL2_TTF_FOUND, if false, do not try to link against
+  SDL2_TTF_VERSION_STRING - human-readable string containing the
+                            version of SDL2_ttf
+
+
+
+This module responds to the following cache variables:
+
+::
+
+  SDL2_TTF_PATH
+    Set a custom SDL2_ttf Library path (default: empty)
+
+  SDL2_TTF_NO_DEFAULT_PATH
+    Disable search SDL2_ttf Library in default path.
+      If SDL2_TTF_PATH (default: ON)
+      Else (default: OFF)
+
+  SDL2_TTF_INCLUDE_DIR
+    SDL2_ttf headers path.
+
+  SDL2_TTF_LIBRARY
+    SDL2_ttf Library (.dll, .so, .a, etc) path.
+
+
+Additional Note: If you see an empty SDL2_TTF_LIBRARY in your project
+configuration, it means CMake did not find your SDL2_ttf library
+(SDL2_ttf.dll, libsdl2_ttf.so, etc). Set SDL2_TTF_LIBRARY to point
+to your SDL2_ttf library, and  configure again. This value is used to
+generate the final SDL2_TTF_LIBRARIES variable and the SDL2::TTF target,
+but when this value is unset, SDL2_TTF_LIBRARIES and SDL2::TTF does not
+get created.
+
+
+$SDL2TTFDIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2TTFDIR used in building SDL2_ttf.
+
+$SDL2DIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2DIR used in building SDL2.
+
+
+
+Created by Amine Ben Hassouna:
+  Adapt FindSDL_ttf.cmake to SDL2_ttf (FindSDL2_ttf.cmake).
+  Add cache variables for more flexibility:
+    SDL2_TTF_PATH, SDL2_TTF_NO_DEFAULT_PATH (for details, see doc above).
+  Add SDL2 as a required dependency.
+  Modernize the FindSDL2_ttf.cmake module by creating a specific target:
+    SDL2::TTF (for details, see doc above).
+
+Original FindSDL_ttf.cmake module:
+  Created by Eric Wing.  This was influenced by the FindSDL.cmake
+  module, but with modifications to recognize OS X frameworks and
+  additional Unix paths (FreeBSD, etc).
+#]=======================================================================]
+
+# SDL2 Library required
+find_package(SDL2 QUIET)
+if(NOT SDL2_FOUND)
+    set(SDL2_TTF_SDL2_NOT_FOUND "Could NOT find SDL2 (SDL2 is required by SDL2_ttf).")
+    if(SDL2_ttf_FIND_REQUIRED)
+        message(FATAL_ERROR ${SDL2_TTF_SDL2_NOT_FOUND})
+    else()
+        if(NOT SDL2_ttf_FIND_QUIETLY)
+            message(STATUS ${SDL2_TTF_SDL2_NOT_FOUND})
+        endif()
+        return()
+    endif()
+    unset(SDL2_TTF_SDL2_NOT_FOUND)
+endif()
+
+
+# Define options for searching SDL2_ttf Library in a custom path
+
+set(SDL2_TTF_PATH "" CACHE STRING "Custom SDL2_ttf Library path")
+
+set(_SDL2_TTF_NO_DEFAULT_PATH OFF)
+if(SDL2_TTF_PATH)
+    set(_SDL2_TTF_NO_DEFAULT_PATH ON)
+endif()
+
+set(SDL2_TTF_NO_DEFAULT_PATH ${_SDL2_TTF_NO_DEFAULT_PATH}
+        CACHE BOOL "Disable search SDL2_ttf Library in default path")
+unset(_SDL2_TTF_NO_DEFAULT_PATH)
+
+set(SDL2_TTF_NO_DEFAULT_PATH_CMD)
+if(SDL2_TTF_NO_DEFAULT_PATH)
+    set(SDL2_TTF_NO_DEFAULT_PATH_CMD NO_DEFAULT_PATH)
+endif()
+
+# Search for the SDL2_ttf include directory
+find_path(SDL2_TTF_INCLUDE_DIR SDL_ttf.h
+        HINTS
+        ENV SDL2TTFDIR
+        ENV SDL2DIR
+        ${SDL2_TTF_NO_DEFAULT_PATH_CMD}
+        PATH_SUFFIXES SDL2
+        # path suffixes to search inside ENV{SDL2DIR}
+        # and ENV{SDL2TTFDIR}
+        include/SDL2 include
+        PATHS ${SDL2_TTF_PATH}
+        DOC "Where the SDL2_ttf headers can be found"
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+    set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+# Search for the SDL2_ttf library
+find_library(SDL2_TTF_LIBRARY
+        NAMES SDL2_ttf
+        HINTS
+        ENV SDL2TTFDIR
+        ENV SDL2DIR
+        ${SDL2_TTF_NO_DEFAULT_PATH_CMD}
+        PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+        PATHS ${SDL2_TTF_PATH}
+        DOC "Where the SDL2_ttf Library can be found"
+)
+
+# Read SDL2_ttf version
+if(SDL2_TTF_INCLUDE_DIR AND EXISTS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h")
+    file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_TTF_MAJOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_TTF_MINOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_TTF_PATCHLEVEL[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+SDL_TTF_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_MAJOR "${SDL2_TTF_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_TTF_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_MINOR "${SDL2_TTF_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_TTF_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_PATCH "${SDL2_TTF_VERSION_PATCH_LINE}")
+    set(SDL2_TTF_VERSION_STRING ${SDL2_TTF_VERSION_MAJOR}.${SDL2_TTF_VERSION_MINOR}.${SDL2_TTF_VERSION_PATCH})
+    unset(SDL2_TTF_VERSION_MAJOR_LINE)
+    unset(SDL2_TTF_VERSION_MINOR_LINE)
+    unset(SDL2_TTF_VERSION_PATCH_LINE)
+    unset(SDL2_TTF_VERSION_MAJOR)
+    unset(SDL2_TTF_VERSION_MINOR)
+    unset(SDL2_TTF_VERSION_PATCH)
+endif()
+
+set(SDL2_TTF_LIBRARIES ${SDL2_TTF_LIBRARY})
+set(SDL2_TTF_INCLUDE_DIRS ${SDL2_TTF_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_ttf
+        REQUIRED_VARS SDL2_TTF_LIBRARIES SDL2_TTF_INCLUDE_DIRS
+        VERSION_VAR SDL2_TTF_VERSION_STRING)
+
+
+mark_as_advanced(SDL2_TTF_PATH
+        SDL2_TTF_NO_DEFAULT_PATH
+        SDL2_TTF_LIBRARY
+        SDL2_TTF_INCLUDE_DIR)
+
+
+if(SDL2_TTF_FOUND)
+
+    # SDL2::TTF target
+    if(SDL2_TTF_LIBRARY AND NOT TARGET SDL2::TTF)
+        add_library(SDL2::TTF UNKNOWN IMPORTED)
+        set_target_properties(SDL2::TTF PROPERTIES
+                IMPORTED_LOCATION "${SDL2_TTF_LIBRARY}"
+                INTERFACE_INCLUDE_DIRECTORIES "${SDL2_TTF_INCLUDE_DIR}"
+                INTERFACE_LINK_LIBRARIES SDL2::SDL2)
+    endif()
+endif()

--- a/cmake/FindSDL_gpu.cmake
+++ b/cmake/FindSDL_gpu.cmake
@@ -1,0 +1,20 @@
+if(NOT TARGET SDL_gpu)
+    include(FetchContent)
+    FetchContent_Declare(
+        SDL_gpu
+        GIT_REPOSITORY https://github.com/grimfang4/sdl-gpu.git
+        GIT_TAG        47a3e2b2a9326c33ad6f177794705987399de8cf
+    )
+    FetchContent_MakeAvailable(SDL_gpu)
+
+    set(SDL_gpu_LIBRARY SDL_gpu)
+    set(SDL_gpu_INCLUDE_DIR "${SDL_gpu_SOURCE_DIR}/include")
+    target_include_directories(SDL_gpu PUBLIC "${SDL_gpu_INCLUDE_DIR}")
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(SDL_gpu
+        REQUIRED_VARS
+        SDL_gpu_LIBRARY
+        SDL_gpu_INCLUDE_DIR
+    )
+endif ()

--- a/src/display.c
+++ b/src/display.c
@@ -13,18 +13,21 @@
 #include "atoms.h"
 #include "visual.h"
 #include "font.h"
-#include <jni.h>
+#ifdef HAVE_JNI
+#  include <jni.h>
+#endif /* HAVE_JNI */
 #include <SDL_gpu.h>
 #include <X11/X.h>
 #include <X11/Xutil.h>
 
-
+#ifdef HAVE_JNI
 jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     setenv("DISPLAY", ":0", 0);
     return JNI_VERSION_1_4;
 }
+#endif /* HAVE_JNI */
 
-void __attribute__((constructor)) _init() {
+void __attribute__((constructor)) init() {
     setenv("DISPLAY", ":0", 0);
 }
 

--- a/src/region.c
+++ b/src/region.c
@@ -2,7 +2,7 @@
 #include "X11/Xutil.h"
 #include <inttypes.h>
 #include <X11/Xregion.h>
-#include "pixman.h"
+#include <pixman.h>
 #include "drawing.h"
 #include "resourceTypes.h"
 


### PR DESCRIPTION
This allowed me to compile the library on Ubuntu with `libsdl2-dev libsdl2-ttf-dev libpixman-1-dev` installed and `set(CMAKE_POSITION_INDEPENDENT_CODE ON)` set.

Closes #41.